### PR TITLE
added confirm prompt when clicking "Clear Deck" 新増確認提示

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,7 +444,7 @@
 					</table>
 				</td>		
 				<td style="vertical-align:text-top">
-					<button onclick="$('#cardinformation').css('visibility', 'hidden');dataInit()">Clear Deck</button>
+					<button onclick="onClearDeckEvent()">Clear Deck</button>
 					<!-- <button style="float: right;" onclick="checkDeck();">Exam</button> -->
 					<button onclick="$('#cardinformation').css('visibility', 'hidden');customizeWindowEvent('view');">Deck View</button>
 					<button onclick="$('#cardinformation').css('visibility', 'hidden');customizeWindowEvent('list');">Card List</button>

--- a/js/function.js
+++ b/js/function.js
@@ -3202,3 +3202,12 @@ function showVersion()
 	
 	alert(str);
 }
+
+function onClearDeckEvent()
+{
+	if (confirm('Confirm?'))
+	{
+		$('#cardinformation').css('visibility', 'hidden');
+		dataInit();
+	}
+}


### PR DESCRIPTION
# What
A JS native confirm prompt has been added when the user clicks "Clear Deck" button.
當用戶按下"Clear Deck"時，新增用戶提示以確認用戶是否清除牌組。
![pr](https://github.com/relax100002000/WIXOSS_deckeditor/assets/50672416/e3d48fac-5090-47d3-a70d-e65177d1789d)

# Why
Some users reported that they always misclick the "Clear Deck" button when building deck, affecting the user experience negatively.
有用戶反映他們在構築牌組時經常錯誤地按下"Clear Deck"按鈕，令用戶體驗造成負面影響。

# How
- Added a function called `onClearDeckEvent()` in `js/function.js`, migrated the original logic in the "Clear Deck" button, and added a `confirm()` condition. 
在`js/function.js`新增一個名為`onClearDeckEvent()`的函數，將"Clear Deck"按鈕的邏輯搬遷到該函數內，並新增一個`confirm()`條件。
- Replaced the original logic by calling `onClearDeckEvent()`.
取代原有邏輯，並改為呼叫`onClearDeckEvent()`。